### PR TITLE
chore: change to create draft releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,4 +52,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          gh release create ${{ inputs.version }} --generate-notes
+          gh release create ${{ inputs.version }} --generate-notes --draft

--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ jobs:
 2. Click `Run workflow`.
 3. Input version.
 4. Click `Run workflow`.
+5. Open Releases page.
+6. Amend draft release.
+7. Uncheck `Set as a pre-release`.
+8. Click `Update release`.


### PR DESCRIPTION
When adding "breaking changes", the automatically generated release notes should be rewritten before release. Therefore, change the release workflow to create a draft release.