### PR TITLE
feat: Add input for specifying token explicitly

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -25,6 +25,18 @@ inputs:
     description: 'if `true`, enclose the output log to the summary in a detail tag.'
     required: false
     default: "true"
+  token:
+    description: 'GitHub token'
+    required: false
+    default: ${{ github.token }}
+  renovate-username:
+    description: 'Renovate username'
+    required: false
+    default: "GitHub Action"
+  renovate-git-author:
+    description: 'Renovate git author'
+    required: false
+    default: "GitHub Action <action@github.com>"
 
 runs:
   using: "composite"
@@ -57,9 +69,9 @@ runs:
         #   ref: https://zenn.dev/azrsh/articles/renovate-dry-run-ci#%E5%AE%9F%E8%A3%85-2
         # Use the `GitHub Action' user to make it explicit that the execution is through GitHub Actions.
         #   ref: https://github.com/actions/checkout/issues/13
-        RENOVATE_USERNAME: GitHub Action
-        RENOVATE_GIT_AUTHOR: GitHub Action <action@github.com>
-        RENOVATE_TOKEN: ${{ github.token }}
+        RENOVATE_USERNAME: ${{ inputs.renovate-username }}
+        RENOVATE_GIT_AUTHOR: ${{ inputs.renovate-git-author }}
+        RENOVATE_TOKEN: ${{ inputs.token }}
 
         # Set the log level for Renovate.
         #   ref: https://docs.renovatebot.com/examples/self-hosting/#about-the-log-level-numbers


### PR DESCRIPTION
If I want to use a config.json file that is in a different private repository, I can't do that with `GITHUB_TOKEN`.

I propose to work around this problem by allowing the token to be specified explicitly.
I also allow `renovate-username` and `renovate-git-author` to be set explicitly.
